### PR TITLE
[RFC] introduce "draft" option to allow marginpars with warning

### DIFF
--- a/LaTeX/sigchi.cls
+++ b/LaTeX/sigchi.cls
@@ -181,7 +181,7 @@
 \evensidemargin 1.9cm           % [jdf] idem
 \advance\oddsidemargin by -1in  % Correct for LaTeX gratuitousness
 \advance\evensidemargin by -1in % Correct for LaTeX gratuitousness
-\marginparwidth 40pt            % Margin pars are not allowed.
+\marginparwidth 0pt             % Margin pars are not allowed.
 \marginparsep 11pt              % Horizontal space between outer margin and
                                 % marginal note
 
@@ -734,8 +734,6 @@
 \@twosidetrue
 \@mparswitchtrue
 \def\ds@draft{\overfullrule 5\p@}
-%% CHANGE ON NEXT LINE
-\dooptions
 
 \lineskip \p@
 \normallineskip \p@
@@ -984,9 +982,17 @@
 \newtoks\confinfo
 \def\conferenceinfo#1#2{\global\conf={#1}\global\confinfo{#2}}
 
+
+% Introduce a "draft" option which conditionally enables marginpars with a warning.
 \let\oldmarginpar\marginpar
-\renewcommand{\marginpar}[2][]{\@latex@warning{The marginpar command is not allowed in the `acmconf'
-document style. Remove all occurences before final document submission.}\oldmarginpar[#1]{#2}}
+\renewcommand{\marginpar}[2][]{\@latexerr{The marginpar command is not allowed in the
+  `acmconf' document style.}\@eha}
+\DeclareOption{draft}{
+  \marginparwidth 40pt
+  \renewcommand{\marginpar}[2][]{\@latex@warning{The marginpar command is not allowed in the `acmconf'
+  document style. Remove all occurences before final document submission.}\oldmarginpar[#1]{#2}}
+}
+\dooptions % immediately execute the options at this point.
 
 \mark{{}{}}     % Initializes TeX's marks
 

--- a/LaTeX/sigchi.cls
+++ b/LaTeX/sigchi.cls
@@ -992,7 +992,9 @@
   \renewcommand{\marginpar}[2][]{\@latex@warning{The marginpar command is not allowed in the `acmconf'
   document style. Remove all occurences before final document submission.}\oldmarginpar[#1]{#2}}
 }
-\dooptions % immediately execute the options at this point.
+% Immediately execute the options at this point. Reason is discussed
+% here: https://tex.stackexchange.com/questions/203387/
+\ProcessOptions
 
 \mark{{}{}}     % Initializes TeX's marks
 

--- a/LaTeX/sigchi.cls
+++ b/LaTeX/sigchi.cls
@@ -181,7 +181,7 @@
 \evensidemargin 1.9cm           % [jdf] idem
 \advance\oddsidemargin by -1in  % Correct for LaTeX gratuitousness
 \advance\evensidemargin by -1in % Correct for LaTeX gratuitousness
-\marginparwidth 0pt             % Margin pars are not allowed.
+\marginparwidth 40pt            % Margin pars are not allowed.
 \marginparsep 11pt              % Horizontal space between outer margin and
                                 % marginal note
 
@@ -984,9 +984,9 @@
 \newtoks\confinfo
 \def\conferenceinfo#1#2{\global\conf={#1}\global\confinfo{#2}}
 
-
-\def\marginpar{\@latexerr{The \marginpar command is not allowed in the
-  `acmconf' document style.}\@eha}
+\let\oldmarginpar\marginpar
+\renewcommand{\marginpar}[2][]{\@latex@warning{The marginpar command is not allowed in the `acmconf'
+document style. Remove all occurences before final document submission.}\oldmarginpar[#1]{#2}}
 
 \mark{{}{}}     % Initializes TeX's marks
 


### PR DESCRIPTION
I find it's very helpful to be able to add notes (e.g. using todonotes) to a document when collaborating. However, all these packages fail with sigchi.cls because marginpars are disabled. I'd like to suggest to re-enable them and simultaneously emit a warning.

Added benefit: tools like ShareLatex will then mark the todonotes with little warning signs in the source.
