### PR TITLE
Fixed endtable and endfigure according to subfigure's complaints

### DIFF
--- a/LaTeX/sigchi.cls
+++ b/LaTeX/sigchi.cls
@@ -659,7 +659,7 @@
 \def\ext@figure{lof}
 \def\fnum@figure{Figure \thefigure}
 \def\figure{\@float{figure}}
-\let\endfigure\end@float
+\def\endfigure{\end@float}
 \@namedef{figure*}{\@dblfloat{figure}}
 \@namedef{endfigure*}{\end@dblfloat}
 
@@ -670,7 +670,7 @@
 \def\ext@table{lot}
 \def\fnum@table{Table \thetable}
 \def\table{\@float{table}}
-\let\endtable\end@float
+\def\endtable{\end@float}
 \@namedef{table*}{\@dblfloat{table}}
 \@namedef{endtable*}{\end@dblfloat}
 


### PR DESCRIPTION
`subfigure` complains:

```
Package subfigure Warning: Your document class has a bad definition
 of \endfigure, most likely
 \let\endfigure=\end@float
 which has now been changed to
 \def\endfigure{\end@float}
 because otherwise subsequent changes to \end@float
 (like done by several packages changing float behaviour)
 can't take effect on \endfigure.
 Please complain to your document class author.

Package subfigure Warning: Your document class has a bad definition
 of \endtable, most likely
 \let\endtable=\end@float
 which has now been changed to
 \def\endtable{\end@float}
 because otherwise subsequent changes to \end@float
 (like done by several packages changing float behaviour)
 can't take effect on \endtable.
 Please complain to your document class author.
```

This pull request fixes that and doesn't appear to cause other compilation problems. I am not a TeX expert, though.
