### PR TITLE
Color table hlines to be gray

### DIFF
--- a/LaTeX/proceedings.tex
+++ b/LaTeX/proceedings.tex
@@ -23,6 +23,7 @@
 \usepackage{mathptmx}
 \usepackage[pdftex]{hyperref}
 \usepackage{color}
+\usepackage{colortbl} % color table \hlines
 \usepackage{booktabs}
 \usepackage{textcomp}
 % Some optional stuff you might like/need.
@@ -58,6 +59,9 @@
   }}
 \makeatother
 \urlstyle{leo}
+
+% Make table \hlines 75% gray
+\arrayrulecolor[gray]{.75}
 
 % To make various LaTeX processors do the right thing with page size.
 \def\pprw{8.5in}
@@ -280,7 +284,7 @@ URLs directly in the text, as above.
     % \bottomrule
   \end{tabular}
   \caption{Table captions should be placed below the table. We
-    recommend table lines be 1 point, 25\% black. Minimize use of
+    recommend table lines be 1 point, 75\% grey. Minimize use of
     table grid lines.}~\label{tab:table1}
 \end{table}
 


### PR DESCRIPTION
Recommendations in `proceedings.tex` are to have table lines be gray, but they weren't.
