### PR TITLE
fix references to section headings (due to incorrect case change)

### DIFF
--- a/LaTeX/sigchi.cls
+++ b/LaTeX/sigchi.cls
@@ -1174,6 +1174,7 @@
   \vskip -6pt  % [jdf] less space between section as in the Word template
   \@xsect{#3}\parskip=6pt} % [jdf] paragraph skip shorter
 
+\newcommand{\Sectionformat}[2]{\if@uchead\uppercase{#1}\else#1\fi}
 
 \def\@sect#1#2#3#4#5#6[#7]#8{%
     \ifnum #2>\c@secnumdepth
@@ -1197,11 +1198,7 @@
             \@hangfrom{\hskip #3\relax\@svsec}%
             \begingroup
                 \interlinepenalty \@M
-                \if@uchead
-                    \uppercase{#8}%
-                \else
                     #8%
-                \fi
                 \par
             \endgroup
         \endgroup
@@ -1219,11 +1216,7 @@
             #6%
             \hskip #3\relax
             \@svsec
-            \if@uchead
-                \uppercase{#8}%
-            \else
                 #8%
-            \fi
             \csname #1mark\endcsname{#7}%
             \addcontentsline{toc}{#1}{%
                 \ifnum #2>\c@secnumdepth \else

--- a/LaTeX/sigchi.cls
+++ b/LaTeX/sigchi.cls
@@ -1174,6 +1174,7 @@
   \vskip -6pt  % [jdf] less space between section as in the Word template
   \@xsect{#3}\parskip=6pt} % [jdf] paragraph skip shorter
 
+% pre-define the section format for hyperref, to avoid clash with internal section name
 \newcommand{\Sectionformat}[2]{\if@uchead\uppercase{#1}\else#1\fi}
 
 \def\@sect#1#2#3#4#5#6[#7]#8{%

--- a/LaTeX/sigchi.cls
+++ b/LaTeX/sigchi.cls
@@ -1088,9 +1088,6 @@
 \def\thesubsubsection{\thesubsection.\arabic{subsubsection}} %removed \subsecfnt 29 July 2002 gkmt
 \def\theparagraph{\thesubsubsection.\arabic{paragraph}} %removed \subsecfnt 29 July 2002 gkmt
 
-\newif\if@uchead
-\@ucheadfalse
-
 %% CHANGES: NEW NOTE
 %% NOTE: OK to use old-style font commands below, since they were
 %% suitably redefined for LaTeX2e
@@ -1098,8 +1095,8 @@
 %\setcounter{secnumdepth}{3}
 \setcounter{secnumdepth}{-2} % DLC
 \def\part{%
-    \@startsection{part}{9}{\z@}{-10\p@ \@plus -4\p@ \@minus -2\p@}
-        {4\p@}{\normalsize\@ucheadtrue}%
+    \@startsection{part}{0}{\z@}{-10\p@ \@plus -4\p@ \@minus -2\p@}
+        {4\p@}{\normalsize}%
 }
 
 % Rationale for changes made in next four definitions:
@@ -1115,7 +1112,7 @@
 % 12 Jan 2000 gkmt
 \def\section{%
     \@startsection{section}{1}{\z@}{8pt plus 3pt minus 3pt}%
-    {0.5pt}{\baselineskip=14pt\secfnt\@ucheadtrue}%
+    {0.5pt}{\baselineskip=14pt\secfnt}%
 }
 
 \def\subsection{%
@@ -1175,7 +1172,7 @@
   \@xsect{#3}\parskip=6pt} % [jdf] paragraph skip shorter
 
 % pre-define the section format for hyperref, to avoid clash with internal section name
-\newcommand{\Sectionformat}[2]{\if@uchead\uppercase{#1}\else#1\fi}
+\newcommand{\Sectionformat}[2]{\ifnum#2<2\uppercase{#1}\else#1\fi}
 
 \def\@sect#1#2#3#4#5#6[#7]#8{%
     \ifnum #2>\c@secnumdepth


### PR DESCRIPTION
Should fix #49, #52 (thanks to @matsch-o0 for providing the necessary hint).

Minor issue with this fix: it only works when `hyperref` package is loaded. If it's not, then the automatic capitalization won't happen.

Background, since this wasn't an easy one: in the `@sect` macro, parameter `#8` is intended to just be the section name, but due to `hyperref`, it gets turned into something like `\Hy@SectionAnchorHref {section*.5}\Sectionformat {Introduction}{1}`. Running `\uppercase` on that will convert all parameters into caps, _including_ `section*.5`, which will then fail to match with the original TOC entry. 

Luckily, `hyperref` already allows to pre-define a `\Sectionformat` command, which does exactly what the name suggests. Second optional parameter is the heading level (currently unused), might even allow to get rid of `@uchead` in the future.
