### PR TITLE
Fixed section references (a better way?)

### DIFF
--- a/LaTeX/proceedings.tex
+++ b/LaTeX/proceedings.tex
@@ -86,6 +86,7 @@
   linkcolor=black,
   urlcolor=linkColor,
   breaklinks=true,
+  hypertexnames=false
 }
 
 % create a shortcut to typeset table headings

--- a/LaTeX/sigchi.cls
+++ b/LaTeX/sigchi.cls
@@ -455,7 +455,7 @@
 \newcount\sectioncntr
 \global\sectioncntr=1
 
-\setcounter{secnumdepth}{3}
+\setcounter{secnumdepth}{0}
 
 \def\appendix{\par
 \section*{APPENDIX}
@@ -1095,8 +1095,6 @@
 %% NOTE: OK to use old-style font commands below, since they were
 %% suitably redefined for LaTeX2e
 %% END CHANGES
-%\setcounter{secnumdepth}{3}
-\setcounter{secnumdepth}{-2} % DLC
 \def\part{%
     \@startsection{part}{9}{\z@}{-10\p@ \@plus -4\p@ \@minus -2\p@}
         {4\p@}{\normalsize\@ucheadtrue}%
@@ -1177,7 +1175,7 @@
 
 \def\@sect#1#2#3#4#5#6[#7]#8{%
     \ifnum #2>\c@secnumdepth
-        \let\@svsec\@empty
+        \let\@svsec\@\refstepcounter{#1}
     \else
         \refstepcounter{#1}%
         \edef\@svsec{%
@@ -1409,7 +1407,7 @@
 \setcounter{enumi}{1}
 \def\thebibliography#1{%
     \section{%
-       {REFERENCES}
+       {References}
         \@mkboth{{\refname}}{{\refname}}%
     }%
 %    \list{[\arabic{enumi}]}{%


### PR DESCRIPTION
Another way to fix #49 and #52, instead of #53.

I've used this for several years without problems: instead of relying on the link names (and their upper/lowercase), fix the counter instead, which seems to be the actual problem. This also means that the fix doesn't depend on hyperref. In my opinion this makes it a better way to solve the issue.

This change also fixes the warning about "destination with the same identifier" (caused by duplicate links - see the change in proceedings.tex); and, the uppercase of REFERENCES in sigchi.cls - there's no need to have it in uppercase here, as it is automatically capitalised in the output. By doing this, it means that all the PDF bookmarks are in normal case, for consistency.
