### PR TITLE
Allow to copy-paste the ACM bibstrip in the Permission Release Form for EA format

### DIFF
--- a/LaTeX/extended-abstract.tex
+++ b/LaTeX/extended-abstract.tex
@@ -104,6 +104,15 @@
 
 \begin{document}
 
+%% For the camera ready, use the commands provided by the ACM in the Permission Release Form.
+%\CopyrightYear{2007}
+%\setcopyright{rightsretained}
+%\conferenceinfo{WOODSTOCK}{'97 El Paso, Texas USA}
+%\isbn{0-12345-67-8/90/01}
+%\doi{http://dx.doi.org/10.1145/2858036.2858119}
+%% Then override the default copyright message with the \acmcopyright command.
+%\copyrightinfo{\acmcopyright}
+
 \maketitle
 
 % Uncomment to disable hyphenation (not recommended)

--- a/LaTeX/sigchi-ext.cls
+++ b/LaTeX/sigchi-ext.cls
@@ -103,7 +103,7 @@
 \newcommand*{\CopyrightYear}[1]{} % Actually not used, but needed for consistency
 \newcommand*{\acmPrice}[1]{}      % Actually not used, but needed for consistency
 \newcommand*{\conferenceinfo}[2]{\gdef\@crconferenceinfo{\emph{#1}, #2}}
-\newcommand*{\isbn}[1]{\gdef\@crisbn{ACM~#1}.}
+\newcommand*{\isbn}[1]{\gdef\@crisbn{ACM~#1.}}
 \newcommand*{\doi}[1]{\gdef\@crdoi{\urlstyle{crc}\url{#1}}}
 % The follwing command typesets the required ACM bibstrip.
 % It must be invoked between \begin{document} and \maketitle, either after or before CCS codes.

--- a/LaTeX/sigchi-ext.cls
+++ b/LaTeX/sigchi-ext.cls
@@ -97,6 +97,25 @@
 
 \newcommand*{\copyrightinfo}[1]{\gdef\@copyrightinfo{\raggedright#1}}
 
+% Allow to copy-paste the ACM bibstrip in the Permission Release Form.
+\RequirePackage{acmcopyright}
+% Define the required commands.
+\newcommand*{\CopyrightYear}[1]{} % Actually not used, but needed for consistency
+\newcommand*{\acmPrice}[1]{}      % Actually not used, but needed for consistency
+\newcommand*{\conferenceinfo}[2]{\gdef\@crconferenceinfo{\emph{#1}, #2}}
+\newcommand*{\isbn}[1]{\gdef\@crisbn{ACM~#1}.}
+\newcommand*{\doi}[1]{\gdef\@crdoi{\urlstyle{crc}\url{#1}}}
+% The follwing command typesets the required ACM bibstrip.
+% It must be invoked between \begin{document} and \maketitle, either after or before CCS codes.
+% So just use \copyrightinfo{\acmcopyright} to override the manual copyright info.
+\newcommand*{\acmcopyright}{
+  \@copyrightpermission\par\smallskip
+  \@copyrightowner\par
+  \@crconferenceinfo\par
+  \@crisbn\par
+  \@crdoi
+}
+
 \def\keywords{
 \section*{Author Keywords}
 }
@@ -184,6 +203,7 @@
 % Define a (compact) global style for URLs, rather than the default one
 % \def\url@leostyle{\@ifundefined{selectfont}{\def\UrlFont{\sf}}{\def\UrlFont{\small\bf\ttfamily}}}
 \def\url@leostyle{\@ifundefined{selectfont}{\def\UrlFont{\sf}}{\def\UrlFont{\small\sffamily}}}
+\def\url@crcstyle{\@ifundefined{selectfont}{\def\UrlFont{\sf}}{\def\UrlFont{\scriptsize\sffamily}}}
 \urlstyle{leo}
 
 %% Fix Hypenation - to restore hyphenation we need this package. 


### PR DESCRIPTION
The Extended Abstracts template is lacking the functionality of PR #81. This PR achieves the same goal.

These changes allow to conveniently copy and paste the commands provided by the ACM in the Permission Release Form. For instance, the following snippet:

```
\CopyrightYear{2016} 
\setcopyright{rightsretained} 
\conferenceinfo{MobileHCI '16 Adjunct}{September 06-09, 2016, Florence, Italy} 
\isbn{978-1-4503-4413-5/16/09}
\doi{http://dx.doi.org/10.1145/2957265.2961833}

\copyrightinfo{\acmcopyright}
```

Produces the following bibstrip:

```
Permission to make digital or hard copies of part or all of this work for personal or classroom use is granted without fee provided that copies are not made or distributed for profit or commercial advantage and that copies bear this notice and the full citation on the first page. Copyrights for third-party components of this work must be honored. For all other uses, contact the Owner/Author. 
Copyright is held by the owner/author(s).
MobileHCI '16 Adjunct, September 06-09, 2016, Florence, Italy
ACM 978-1-4503-4413-5/16/09.
http://dx.doi.org/10.1145/2957265.2961833
```
