### PR TITLE
Ensure that DOI URL is typesetted in roman font inside ACM bibstrip

### DIFF
--- a/LaTeX/sigchi.cls
+++ b/LaTeX/sigchi.cls
@@ -1580,10 +1580,9 @@
 \isbn{978-1-4503-2138-9}
 
 \RequirePackage{url}
-\urlstyle{rm}
 \def\doi#1{\def\@doi{#1}}
 \doi{10.1145/1235}
-\def\printdoi#1{\url{#1}}
+\def\printdoi#1{\urlstyle{rm}\url{#1}}
 
 
 


### PR DESCRIPTION
In `proceedings.tex`:
```
...
\definecolor{linkColor}{RGB}{6,125,233}
\hypersetup{%
...
  urlcolor=linkColor,
...
```
The `urlcolor` option overrides the `\urlstyle{rm}` command in `sigchi.cls`: 
https://github.com/sigchi/Document-Formats/blob/master/LaTeX/sigchi.cls#L1583

Causing this:
![doi-before](https://cloud.githubusercontent.com/assets/1146339/21421135/8eb3a6d0-c831-11e6-97cd-a32ffc6e138c.png)

This PR produces this:
![doi-after](https://cloud.githubusercontent.com/assets/1146339/21421134/8eac1bfe-c831-11e6-9df0-94d6e761d6e3.png)